### PR TITLE
Issue 64, exit code for

### DIFF
--- a/05_Execution/single_command_utils3.c
+++ b/05_Execution/single_command_utils3.c
@@ -50,9 +50,8 @@ void	executing_execve(
 {
 	if (ft_strcmp(params->result->cmd[0], "") == 0)
 	{
-		ft_dprintf(2, "command not found\n");
 		clean_up_function(params, env);
-		exit(127);
+		exit(EXIT_SUCCESS);
 	}
 	if (access(params->result->cmd[0], F_OK) == 0)
 		params->command_path = params->result->cmd[0];

--- a/05_Execution/single_command_utils4.c
+++ b/05_Execution/single_command_utils4.c
@@ -91,6 +91,8 @@ void	child_process_other_cases(
 int	handle_fork_plus_executing_child(
 			t_redirect_single_command_params *params, char ***env)
 {
+	if (*params->exit_status != 0)
+		return (-1);
 	signal(SIGINT, SIG_DFL);
 	signal(SIGQUIT, SIG_DFL);
 	params->pid = fork();


### PR DESCRIPTION
changed exit code when cmd[0] = '' 
early exits for cases in single when exit_status != 0 at execution fork.
meaning if heredoc fails, nothing else runs.