### PR TITLE
Wichee parser module

### DIFF
--- a/01_Lexing/ft_strchr_ignore_quotes.c
+++ b/01_Lexing/ft_strchr_ignore_quotes.c
@@ -11,6 +11,26 @@
 /* ************************************************************************** */
 #include "../includes/minishell.h"
 
+/**
+ * @function: ft_has_quote
+ * @brief: checks if quotes exist in string
+ *
+ * @param string: input string
+ * @return: 1 or 0
+ */
+int	ft_has_quote(char *string)
+{
+	if (!string)
+		return (0);
+	while (*string)
+	{
+		if (*string == '\'' || *string == '\"')
+			return (1);
+		string++;
+	}
+	return (0);
+}
+
 char	*ft_strchr_ignore_quotes(const char *s, int c)
 {
 	unsigned char	t;

--- a/01_Lexing/lexer.c
+++ b/01_Lexing/lexer.c
@@ -39,7 +39,8 @@ t_lex_data	*lexer_token_data(char *input, int is_first_token,
 	data->in_quote = in_quote;
 	data->is_hd_delimiter = is_hd_delimiter;
 	data->is_fd = is_fd;
-	data->is_variable = 0;
+	data->has_val_var = 0;
+	data->has_var = has_variable(input);
 	data->type = lexer_token_type_a(input, is_first_token);
 	if (data->type == 42)
 		data->type = lexer_token_type_b(input, in_quote, is_hd_delimiter,
@@ -69,7 +70,8 @@ static t_list	*create_token_node(t_lex_init_state *state, char **tokens,
 			state->is_hd_delimiter, state->is_fd);
 	if (!data)
 		return (NULL);
-	data->is_variable = has_valid_variable(data->raw_string, env);
+	if (data->has_var)
+		data->has_val_var = has_valid_variable(data->raw_string, env);
 	if (state->i == 0)
 		first_node = ft_lstnew(data);
 	else

--- a/01_Lexing/lexer_utils.c
+++ b/01_Lexing/lexer_utils.c
@@ -13,10 +13,44 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: has_variable
+ * @brief: function checks if string contains expansion variables.
+ * 
+ * @param input: input string
+ * @return: 1 if contains , 0 is not
+ */
+int	has_variable(char *input)
+{
+	int		in_single_quote;
+	int		in_d_quote;
+	int		i;
+
+	in_single_quote = 0;
+	in_d_quote = 0;
+	i = 0;
+	if (!input)
+		return (0);
+	while (input[i])
+	{
+		if (handle_quote_status(input, &in_single_quote, &in_d_quote, &i) == 1)
+			;
+		else if ((input[i] == '$' && input[i + 1] == '?'))
+			return (1);
+		else if ((input[i] == '$' && ft_is_env(input[i + 1]))
+			&& (!in_single_quote || in_d_quote))
+			return (1);
+		else
+			i++;
+	}
+	return (0);
+}
+
+/**
  * @function: has_valid_variable
  * @brief: function checks if string contains valid expansion variable.
  * 
  * @param input: input string
+ * @param env: current envp
  * @return: 1 if contains , 0 is not
  */
 int	has_valid_variable(char *input, char **env)
@@ -24,24 +58,23 @@ int	has_valid_variable(char *input, char **env)
 	int		in_single_quote;
 	int		in_d_quote;
 	int		i;
-	char	*env_var;
+	int		in_env_var;
 
 	in_single_quote = 0;
 	in_d_quote = 0;
 	i = 0;
-	env_var = NULL;
 	if (!input)
 		return (0);
 	while (input[i])
 	{
-		env_var = ft_var_exp(&input, i, env);
+		in_env_var = has_env_variable(input, env, i);
 		if (handle_quote_status(input, &in_single_quote, &in_d_quote, &i) == 1)
 			;
 		else if ((input[i] == '$' && input[i + 1] == '?'))
 			return (1);
 		else if ((input[i] == '$' && ft_is_env(input[i + 1]))
-			&& (!in_single_quote || in_d_quote) && env_var)
-			return (free(env_var), 1);
+			&& (!in_single_quote || in_d_quote) && in_env_var)
+			return (1);
 		else
 			i++;
 	}
@@ -66,24 +99,6 @@ t_lex_init_state	*ft_lexer_init_state(t_lex_init_state *state)
 	state->is_hd_delimiter = 0;
 	state->is_fd = 0;
 	return (state);
-}
-
-/**
- * @function: ft_print_tokens
- * @brief: function that takes the list and prints it.
- * 
- * @param token_data: pointer to the head of the list
- * @return: no return value, void function.
- */
-void	ft_print_tokens(t_list *token_data)
-{
-	while (token_data)
-	{
-		ft_printf("Token is %s, Token Type is %d\n",
-			((t_lex_data *)(token_data->content))->raw_string,
-			((t_lex_data *)(token_data->content))->type);
-		token_data = token_data->next;
-	}
 }
 
 /**

--- a/02_Expansion/expansion.c
+++ b/02_Expansion/expansion.c
@@ -13,6 +13,33 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: handle_quote_status_val_var
+ * @brief: assigns flags to quotes
+ *
+ * @param input: address to the pointer of the
+ * string(string by reference)
+ * @param in_single_quote: point to the index value of where '$' is found
+ * @param in_double_quote: env variables copied from main
+ * @param i: current count
+ * @return: 1 if flags change or 0
+ */
+int	handle_quote_status_val_var(char *input, int *in_single_quote,
+	int *in_d_quote, int *i)
+{
+	if (input[*i] == '\"' && !(*in_single_quote))
+	{
+		*in_d_quote = !(*in_d_quote);
+		return (1);
+	}
+	else if (input[*i] == '\'' && !(*in_d_quote))
+	{
+		*in_single_quote = !(*in_single_quote);
+		return (1);
+	}
+	return (0);
+}
+
+/**
  * @function: handle_quote_status
  * @brief: assigns flags to quotes
  *
@@ -52,7 +79,7 @@ int	handle_quote_status(char *input, int *in_single_quote,
  * @param env: env variables copied from main
  *
  */
-static void	handle_env_variable(char **input, int *i, char **env)
+void	handle_env_variable(char **input, int *i, char **env)
 {
 	char	*env_var;
 

--- a/02_Expansion/expansion_utils_a.c
+++ b/02_Expansion/expansion_utils_a.c
@@ -13,6 +13,22 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: handle_has_var
+ * @brief: takes care of expansion within ft_expansion_tokens
+ *
+ * @param data: token data
+ */
+void	handle_has_var(t_lex_data *data, char **env, int *exit_status)
+{
+	if (data->has_val_var)
+		data->raw_string = expansion_val_var(data->raw_string,
+				env, exit_status);
+	else
+		data->raw_string = expansion_string(data->raw_string, 0,
+				env, exit_status);
+}
+
+/**
  * @function: expansion_replace_string
  * @brief: string replacement function for the expansion step.
  * 

--- a/02_Expansion/expansion_utils_b.c
+++ b/02_Expansion/expansion_utils_b.c
@@ -74,13 +74,10 @@ static void	handle_remove_quote(t_lex_data *data)
 	if (data->type != TOKEN_RD_FD && (*data->raw_string == '\0'
 			|| ft_is_only_whitespace(data->raw_string)))
 		handle_empty_expansion(data);
-	if (((data->type == TOKEN_STRING || data->type == TOKEN_COMMAND
-				|| data->type == TOKEN_INQUOTE || data->type == TOKEN_RD_FD)
-			&& ft_has_quote(data->raw_string))
-		&& !data->is_variable)
+	if ((data->type == TOKEN_STRING || data->type == TOKEN_COMMAND
+			|| data->type == TOKEN_INQUOTE || data->type == TOKEN_RD_FD)
+		&& !data->has_val_var)
 		data->raw_string = ft_remove_quote(data->raw_string);
-	if (data->in_quote && data->is_variable)
-		data->raw_string = ft_remove_inquote(data->raw_string);
 }
 
 /**
@@ -101,8 +98,7 @@ t_list	*ft_expansion_tokens(t_list **token_data, char **env,
 		|| data->type == TOKEN_VARIABLE || data->type == TOKEN_RD_FD
 		|| data->type == TOKEN_STRING)
 	{
-		data->raw_string = expansion_string(data->raw_string, 0,
-				env, exit_status);
+		handle_has_var(data, env, exit_status);
 		if (data->type == TOKEN_VARIABLE && data->is_first_token)
 			data->type = TOKEN_COMMAND;
 		if (data->type == TOKEN_VARIABLE)

--- a/02_Expansion/expansion_utils_c.c
+++ b/02_Expansion/expansion_utils_c.c
@@ -13,6 +13,26 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: has_valid_variable
+ * @brief: function checks if string contains expansion variable.
+ * 
+ * @param input: input string
+ * @param env: current envp
+ * @param i: index in string
+ * @return: 1 if contains , 0 is not
+ */
+int	has_env_variable(char *input, char **env, int i)
+{
+	char	*env_var;
+
+	env_var = ft_var_exp(&input, i, env);
+	if (!env_var)
+		return (0);
+	else
+		return (free(env_var), 1);
+}
+
+/**
  * @function: handle_word_split
  * @brief: handles additional word splitting after the expansion step
  *
@@ -119,24 +139,4 @@ char	*ft_remove_quote(char *string)
 			i++;
 	}
 	return (string);
-}
-
-/**
- * @function: ft_has_quote
- * @brief: checks if quotes exist in string
- *
- * @param string: input string
- * @return: 1 or 0
- */
-int	ft_has_quote(char *string)
-{
-	if (!string)
-		return (0);
-	while (*string)
-	{
-		if (*string == '\'' || *string == '\"')
-			return (1);
-		string++;
-	}
-	return (0);
 }

--- a/02_Expansion/expansion_utils_d.c
+++ b/02_Expansion/expansion_utils_d.c
@@ -13,6 +13,47 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: expansion_val_var
+ * @brief: takes input string that contains valid variables
+ * and does variable expansion and quote removal
+ *
+ * @param input: any string, note that this
+ * 	is malloced and needs to be freed after use.
+ * @param env: env variables copied from main
+ *
+ * @return: returns expanded string.
+ */
+char	*expansion_val_var(char *input, char **env,
+	int *exit_status)
+{
+	int		in_single_quote;
+	int		in_d_quote;
+	int		i;
+	char	*status;
+
+	in_single_quote = 0;
+	in_d_quote = 0;
+	i = 0;
+	status = ft_itoa(*exit_status);
+	while (input[i])
+	{
+		handle_quote_status_val_var(input, &in_single_quote, &in_d_quote, &i);
+		if ((input[i] == '\'') && !in_d_quote)
+			input = ft_str_replace(input, i, "");
+		else if ((input[i] == '\"') && !in_single_quote)
+			input = ft_str_replace(input, i, "");
+		else if ((input[i] == '$' && input[i + 1] == '?'))
+			input = ft_str_replace(input, i, status);
+		else if ((input[i] == '$' && ft_is_env(input[i + 1]))
+			&& (!in_single_quote || in_d_quote))
+			handle_env_variable(&input, &i, env);
+		else
+			i++;
+	}
+	return (free(status), input);
+}
+
+/**
  * @function: ft_remove_inquote
  * @brief: remove head and tail quotes if TOKEN_INQUOTE and quotes 
  * are unbalanced.

--- a/05_Execution/multiple_commands_utils10.c
+++ b/05_Execution/multiple_commands_utils10.c
@@ -13,6 +13,23 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: handle_flag_equals_one in handle_arguments function
+ * @brief: moving on to next node and increment i
+ * 
+ * @param t_piping_multiple_command_params *params : structure for
+ 	multiple commands parameters
+ * 
+ * @return: void function
+ */
+
+void	handle_flag_equals_one(
+			t_piping_multiple_command_params *params)
+{
+	params->traverse = params->traverse->next;
+	params->i++;
+}
+
+/**
  * @function: handle_parent_for_handling_forking_process_multi
  * @brief: handle parent process for the function handling forking process below
  * 

--- a/05_Execution/multiple_commands_utils7.c
+++ b/05_Execution/multiple_commands_utils7.c
@@ -13,6 +13,27 @@
 #include "../includes/minishell.h"
 
 /**
+ * @function: handle_ambigious_redirect_m
+ * @brief: handles errors for ambigious redirect
+ * 
+ * @param t_redirect_single_command_params *params: structure for
+ 	single_command parameters
+ * 
+ * @return: void function
+ */
+
+static void	handle_ambigious_redirect_m(
+			t_piping_multiple_command_params *params)
+{
+	if (ft_strcmp(params->result->rd_arg[params->rd_arg_counter], "") == 0)
+	{
+		ft_dprintf(2, "Ambiguous redirect\n");
+		*params->exit_status = 1;
+		params->flag = 1;
+	}
+}
+
+/**
  * @function: handle_file_opening_errors
  * @brief: print error message if file opening fails
  * 
@@ -24,7 +45,8 @@
 
 void	handle_file_opening_errors(t_piping_multiple_command_params *params)
 {
-	if (params->input_fd < 0 || params->output_fd < 0)
+	if (!(ft_strcmp(params->result->rd_arg[params->rd_arg_counter], "") == 0)
+		&& (params->input_fd < 0 || params->output_fd < 0))
 	{
 		ft_dprintf(2, "%s: ", params->result->rd_arg[params->rd_arg_counter]);
 		perror("Error opening file");
@@ -98,6 +120,7 @@ void	handle_file_opening_multiple_commands(
 			continue ;
 		}
 		handling_file_opening_for_redirects(params);
+		handle_ambigious_redirect_m(params);
 		handle_file_opening_errors(params);
 		if (params->flag == 1)
 		{	
@@ -139,21 +162,4 @@ void	handle_heredocs_pipe_number_multiple_commands(
 				params->heredocs_pipe_index = params->heredocs_pipe_number - 1;
 		}
 	}
-}
-
-/**
- * @function: handle_flag_equals_one in handle_arguments function
- * @brief: moving on to next node and increment i
- * 
- * @param t_piping_multiple_command_params *params : structure for
- 	multiple commands parameters
- * 
- * @return: void function
- */
-
-void	handle_flag_equals_one(
-			t_piping_multiple_command_params *params)
-{
-	params->traverse = params->traverse->next;
-	params->i++;
 }

--- a/05_Execution/single_command_utils2.c
+++ b/05_Execution/single_command_utils2.c
@@ -55,6 +55,7 @@ void	handle_file_opening_redirection(
 {
 	if (ft_strcmp(params->result->redirect[params->k], "<") == 0)
 	{
+		handle_ambigious_redirect(params, env);
 		if (params->input_fd > 0)
 			close(params->input_fd);
 		params->input_fd = open(params->result

--- a/includes/execution.h
+++ b/includes/execution.h
@@ -187,8 +187,6 @@ void	handle_file_opening_multiple_commands(
 			t_piping_multiple_command_params *params);
 void	handle_heredocs_pipe_number_multiple_commands(
 			t_piping_multiple_command_params *params);
-void	handle_flag_equals_one(
-			t_piping_multiple_command_params *params);
 
 // multiple_commands_utils8 //
 void	initialise_counter_for_handle_arguments(
@@ -219,6 +217,8 @@ void	reset_and_closing_fds_when_error(
 			t_piping_multiple_command_params *params);
 void	handle_dot_slash_and_slash(
 			t_piping_multiple_command_params *params, char ***env);
+void	handle_flag_equals_one(
+			t_piping_multiple_command_params *params);
 
 // free_pipes.c //
 void	free_pipes(int **pipes, int num_pipes);

--- a/includes/expansion.h
+++ b/includes/expansion.h
@@ -12,11 +12,16 @@
 #ifndef EXPANSION_H
 # define EXPANSION_H
 
+# include "lexer.h"
+
 //expansion.c
 t_list	*expansion(t_list *token_data, char **env, int *exist_status);
 char	*expansion_string(char *input, int ignore_quote, char **env,
 			int *exist_status);
 int		handle_quote_status(char *input, int *in_single_quote,
+			int *in_d_quote, int *i);
+void	handle_env_variable(char **input, int *i, char **env);
+int		handle_quote_status_val_var(char *input, int *in_single_quote,
 			int *in_d_quote, int *i);
 
 //expansion_utils_a.c
@@ -24,6 +29,7 @@ char	*ft_str_replace(char *input, int index, char *rep_substring);
 char	*ft_str_insert(char *input, int index, char *insert_string);
 char	*ft_env_search(char *var, char **env);
 void	expansion_replace_string(char *env_var, int index, char **exp_input);
+void	handle_has_var(t_lex_data *data, char **env, int *exit_status);
 
 //expansion_utils_b.c
 t_list	*ft_expansion_tokens(t_list **token_data, char **env,
@@ -32,13 +38,15 @@ t_list	*ft_expansion_tokens(t_list **token_data, char **env,
 //expansion_utils_c.c
 int		ft_has_whitespace(char *string);
 char	*ft_remove_quote(char *string);
-int		ft_has_quote(char *string);
 t_list	**handle_word_split(char *string, t_list **current_token, char **env);
 t_list	*ft_lstinsert(t_list *node, t_list *current);
+int		has_env_variable(char *input, char **env, int i);
 
 //expansion_utils_d.c
 char	*ft_getenv(char *string, char **env);
 char	*ft_var_exp(char **input, int start_index, char **env);
 int		ft_env_len(const char *input);
 char	*ft_remove_inquote(char *string);
+char	*expansion_val_var(char *input, char **env,
+			int *exit_status);
 #endif

--- a/includes/lexer.h
+++ b/includes/lexer.h
@@ -40,7 +40,8 @@ typedef struct s_lex_data
 	int				is_first_token;
 	int				is_hd_delimiter;
 	int				is_fd;
-	int				is_variable;
+	int				has_val_var;
+	int				has_var;
 }					t_lex_data;
 
 typedef struct s_lex_init_state
@@ -69,11 +70,14 @@ void				handle_retokenize(t_lex_data *data);
 // lexer Utils
 void				ft_free_split(char **split);
 void				ft_free_lex_data(void *data);
-void				ft_print_tokens(t_list *token_data);
 t_lex_init_state	*ft_lexer_init_state(t_lex_init_state *state);
 int					has_valid_variable(char *input, char **env);
+int					has_variable(char *input);
 
 // ft_split_ignore_quotes.c
 char				**ft_split_ignore_quotes(const char *s, char c);
+
+// ft_strchr_ignore_quotes
 char				*ft_strchr_ignore_quotes(const char *s, int c);
+int					ft_has_quote(char *string);
 #endif


### PR DESCRIPTION
TLDR: 
(1) Made a design choice to not follow bash's word splitting and (expansion + quote removal)
(2) Updated Single and Multiple execution for correction error message when ambiguous strings are provided to redirects.

Tokens with valid_variable expansions will have quotes removed at the point of expansion.
expanded strings will be taken as literal strings and will preserve quotes.

There will be a subsequent quote removal step for  TOKEN_STRINGS, COMMANDS, IN_QUOTES and RD_FD. 
If the token had gone through valid_variable expansion it will pass the quote removal step.

This choice means that I will forgo bash accurate word_splitting as I am not able to figure a way to 
(1) preserve the quotes in expansions 
(2) split the string into two or move tokens
(3) remove only quotes that were not from expansions
my quote removal method is a single pass.

Inital attempts at saving index pairs for expanded strings will work. but the metadata will prove unusable after the string is split. making preservation of the quotes impossible.