### PR TITLE
Use of Special -ve range as flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .submission*
 .vscode
 minishell
+minishell_tester

--- a/00_Input/input.c
+++ b/00_Input/input.c
@@ -37,7 +37,7 @@ int	ft_add_whitespace_special(char **input, int i, int in_s_q, int in_d_q)
 		i = ft_add_whitespace_helper(input, i, 1);
 	else if ((*input)[i] == '|' && (*input)[i + 1] == '|' && !in_s_q && !in_d_q)
 		i = ft_add_whitespace_helper(input, i, 1);
-	else if ((*input)[i] == '*' && !!in_s_q && !in_d_q)
+	else if ((*input)[i] == '*' && !in_s_q && !in_d_q)
 		*input = ft_str_insert(*input, i, " ");
 	else if (ft_isspecial((*input)[i]) && !in_s_q && !in_d_q)
 		i = ft_add_whitespace_helper(input, i, 0);

--- a/00_Input/input_validation_helper.c
+++ b/00_Input/input_validation_helper.c
@@ -104,7 +104,7 @@ int	check_quotes_balance(const char *input)
 	{
 		if (*input == '\'' && !double_quote)
 			single_quote = !single_quote;
-		else if (*input == '"' && !single_quote)
+		else if (*input == '\"' && !single_quote)
 			double_quote = !double_quote;
 		input++;
 	}
@@ -121,13 +121,21 @@ int	check_quotes_balance(const char *input)
 int	check_parentheses_balance(const char *input)
 {
 	int	count;
+	int	single_quote;
+	int	double_quote;
 
+	single_quote = 0;
+	double_quote = 0;
 	count = 0;
 	while (*input)
 	{
-		if (*input == '(')
+		if (*input == '\'' && !double_quote)
+			single_quote = !single_quote;
+		else if (*input == '\"' && !single_quote)
+			double_quote = !double_quote;
+		if (*input == '(' && !double_quote && !single_quote)
 			count++;
-		else if (*input == ')')
+		else if (*input == ')' && !double_quote && !single_quote)
 		{
 			if (count == 0)
 				return (0);

--- a/02_Expansion/expansion_utils_b.c
+++ b/02_Expansion/expansion_utils_b.c
@@ -75,9 +75,9 @@ static void	handle_remove_quote(t_lex_data *data)
 			|| ft_is_only_whitespace(data->raw_string)))
 		handle_empty_expansion(data);
 	if ((data->type == TOKEN_STRING || data->type == TOKEN_COMMAND
-			|| data->type == TOKEN_INQUOTE || data->type == TOKEN_RD_FD)
-		&& !data->has_val_var)
+			|| data->type == TOKEN_INQUOTE || data->type == TOKEN_RD_FD))
 		data->raw_string = ft_remove_quote(data->raw_string);
+	data->raw_string = ft_reset_quotes(data->raw_string);
 }
 
 /**
@@ -101,11 +101,11 @@ t_list	*ft_expansion_tokens(t_list **token_data, char **env,
 		handle_has_var(data, env, exit_status);
 		if (data->type == TOKEN_VARIABLE && data->is_first_token)
 			data->type = TOKEN_COMMAND;
-		if (data->type == TOKEN_VARIABLE)
+		else if (data->type == TOKEN_VARIABLE)
 			data->type = TOKEN_STRING;
 		if (data->type == TOKEN_RD_FD)
 			handle_rd_fd(data);
-		else
+		if (data->has_val_var)
 			token_data = handle_word_split(ft_strdup(data->raw_string),
 					token_data, env);
 		data = (t_lex_data *)(*token_data)->content;

--- a/02_Expansion/expansion_utils_d.c
+++ b/02_Expansion/expansion_utils_d.c
@@ -13,47 +13,6 @@
 #include "../includes/minishell.h"
 
 /**
- * @function: expansion_val_var
- * @brief: takes input string that contains valid variables
- * and does variable expansion and quote removal
- *
- * @param input: any string, note that this
- * 	is malloced and needs to be freed after use.
- * @param env: env variables copied from main
- *
- * @return: returns expanded string.
- */
-char	*expansion_val_var(char *input, char **env,
-	int *exit_status)
-{
-	int		in_single_quote;
-	int		in_d_quote;
-	int		i;
-	char	*status;
-
-	in_single_quote = 0;
-	in_d_quote = 0;
-	i = 0;
-	status = ft_itoa(*exit_status);
-	while (input[i])
-	{
-		handle_quote_status_val_var(input, &in_single_quote, &in_d_quote, &i);
-		if ((input[i] == '\'') && !in_d_quote)
-			input = ft_str_replace(input, i, "");
-		else if ((input[i] == '\"') && !in_single_quote)
-			input = ft_str_replace(input, i, "");
-		else if ((input[i] == '$' && input[i + 1] == '?') && !in_single_quote)
-			input = ft_str_replace(input, i, status);
-		else if ((input[i] == '$' && ft_is_env(input[i + 1]))
-			&& (!in_single_quote || in_d_quote))
-			handle_env_variable(&input, &i, env);
-		else
-			i++;
-	}
-	return (free(status), input);
-}
-
-/**
  * @function: ft_remove_inquote
  * @brief: remove head and tail quotes if TOKEN_INQUOTE and quotes 
  * are unbalanced.

--- a/02_Expansion/expansion_utils_e.c
+++ b/02_Expansion/expansion_utils_e.c
@@ -1,0 +1,146 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expansion_utils_e.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: wichee <wichee@student.42singapore.sg      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/12 19:08:22 by wichee            #+#    #+#             */
+/*   Updated: 2024/12/12 19:08:24 by wichee           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+/**
+ * @function: ft_reset_quotes
+ * @brief: will take the
+ */
+char	*ft_reset_quotes(char *env_var)
+{
+	int	i;
+
+	i = 0;
+	if (!env_var)
+		return (NULL);
+	while (env_var[i])
+	{
+		if (env_var[i] == VAR_S_Q)
+			env_var[i] = '\'';
+		else if (env_var[i] == VAR_D_Q)
+			env_var[i] = '\"';
+		else
+			i++;
+	}
+	return (env_var);
+}
+
+/**
+ * @function: ft_replace_quotes
+ * @brief: will take the
+ */
+static char	*ft_replace_quotes(char *env_var)
+{
+	int	i;
+
+	i = 0;
+	if (!env_var)
+		return (NULL);
+	while (env_var[i])
+	{
+		if (env_var[i] == '\'')
+			env_var[i] = VAR_S_Q;
+		else if (env_var[i] == '\"')
+			env_var[i] = VAR_D_Q;
+		else
+			i++;
+	}
+	return (env_var);
+}
+
+/**
+ * @function: ft_var_exp_val_var
+ * @brief: takes an input that starts with a '$',
+	finds the env variable and replaces inplace.
+ *
+ * @param input: the address to the pointer of the input string.
+ * @param start_index: an int which represents the starting
+	index that points to a '$'
+ *
+ * @return: returns a string with the '$VAR' replaced with
+	its corresponding env variable if found, else it returns
+	a string with '$VAR' replaced with a NULL
+ */
+
+static char	*ft_var_exp_val_var(char **input, int start_index, char **env)
+{
+	int		env_len;
+	char	*var;
+	char	*env_var;
+
+	env_len = ft_env_len(*input + start_index);
+	var = ft_substr(*input + start_index, 0, env_len);
+	env_var = ft_env_search(var, env);
+	env_var = ft_replace_quotes(env_var);
+	return (free(var), env_var);
+}
+
+/**
+ * @function: handle_env_variable_val_var
+ * @brief: takes identified parameter
+ * and does variable expansion.
+ *
+ * @param input: address to the pointer of the
+ * string(string by reference)
+ * @param i: index value of where '$' is found
+ * @param env: env variables copied from main
+ *
+ */
+static void	handle_env_variable_val_var(char **input, int *i, char **env)
+{
+	char	*env_var;
+
+	env_var = ft_var_exp_val_var(input, *i, env);
+	expansion_replace_string(env_var, *i, input);
+	if (env_var)
+	{
+		*i += ft_strlen(env_var);
+		free(env_var);
+	}
+}
+
+/**
+ * @function: expansion_val_var
+ * @brief: takes input string that contains valid variables
+ * and does variable expansion and quote removal
+ *
+ * @param input: any string, note that this
+ * 	is malloced and needs to be freed after use.
+ * @param env: env variables copied from main
+ *
+ * @return: returns expanded string.
+ */
+char	*expansion_val_var(char *input, char **env, int *exit_status)
+{
+	int		in_single_quote;
+	int		in_d_quote;
+	int		i;
+	char	*status;
+
+	in_single_quote = 0;
+	in_d_quote = 0;
+	i = 0;
+	status = ft_itoa(*exit_status);
+	while (input[i])
+	{
+		handle_quote_status_val_var(input, &in_single_quote, &in_d_quote, &i);
+		if ((input[i] == '$' && input[i + 1] == '?') && !in_single_quote)
+			input = ft_str_replace(input, i, status);
+		else if ((input[i] == '$' && ft_is_env(input[i + 1]))
+			&& (!in_single_quote || in_d_quote))
+			handle_env_variable_val_var(&input, &i, env);
+		else
+			i++;
+	}
+	return (free(status), input);
+}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS = -lreadline
 # Source files names for each directory
 INPUT_FILES = input.c	input_utils.c	input_validation.c	input_validation_helper.c
 LEXER_FILES = lexer.c	tokenize.c	lexer_utils.c	ft_split_ignore_quotes.c	ft_strchr_ignore_quotes.c
-EXPANSION_FILES = expansion.c	expansion_utils_a.c	expansion_utils_b.c	expansion_utils_c.c	expansion_utils_d.c
+EXPANSION_FILES = expansion.c	expansion_utils_a.c	expansion_utils_b.c	expansion_utils_c.c	expansion_utils_d.c	expansion_utils_e.c
 PARSER_FILES = parser.c	parser_utils_a.c	parser_utils_b.c	parser_rd_helper.c	parser_rd_helper_b.c	parser_recursive_descent.c	parser_ast_to_ll.c	parser_exec.c
 REDIRECTION_FILES = path_construction.c	path_construction_utils.c
 EXECUTION_FILES = single_command.c	single_command_utils1.c	single_command_utils2.c	single_command_utils3.c	single_command_utils4.c	single_command_utils5.c	single_command_utils6.c	single_command_utils7.c	single_command_utils8.c	single_command_utils9.c	single_command_utils10.c	single_command_utils11.c	multiple_commands.c	multiple_commands_utils1.c	multiple_commands_utils2.c	multiple_commands_utils3.c	multiple_commands_utils4.c	multiple_commands_utils5.c	multiple_commands_utils6.c	multiple_commands_utils7.c	multiple_commands_utils8.c	multiple_commands_utils9.c	multiple_commands_utils10.c	free_pipes.c

--- a/includes/expansion.h
+++ b/includes/expansion.h
@@ -47,6 +47,10 @@ char	*ft_getenv(char *string, char **env);
 char	*ft_var_exp(char **input, int start_index, char **env);
 int		ft_env_len(const char *input);
 char	*ft_remove_inquote(char *string);
+
+//expansion_utils_e.c
 char	*expansion_val_var(char *input, char **env,
 			int *exit_status);
+char	*ft_reset_quotes(char *env_var);	
+
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -12,6 +12,8 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
+# define VAR_S_Q -24 
+# define VAR_D_Q -42
 # include "../Libft/libft.h"
 # include "../Libft/ft_printf.h"
 # include "../Libft/ft_dprintf.h"


### PR DESCRIPTION
Used special -ve chars to replace quotes in expanded strings which will fix the issue of word_splitting while preserving quotes in expanded strings